### PR TITLE
reproduce 5068d84

### DIFF
--- a/kmod/bug-2feab24.c
+++ b/kmod/bug-2feab24.c
@@ -17,7 +17,7 @@ static void controller_init(void) {
 
 static void controller_body(void) {
   for (int i = 0; i < 1000; i++) {
-    send_sigcode(busy_task, SIGCODE_FORK_PIN, 100);
+    send_sigcode2(busy_task, SIGCODE_FORK_PIN, 100, 1);
   }
 
   for (int i = 0; i < 1000; i++) {

--- a/kmod/bug-5068d84.c
+++ b/kmod/bug-5068d84.c
@@ -1,0 +1,63 @@
+#include <linux/delay.h>
+#include <linux/kthread.h>
+
+#include "controller.h"
+#include "internal.h"
+#include "ksym.h"
+#include "logging.h"
+
+#define TARGET_TASK "test-proc"
+#define CGROUP_TASK "cgroup-proc"
+
+static struct task_struct *busy_task;
+static struct task_struct *cgroup_task;
+
+static void controller_init(void) {
+  busy_task = poll_task(TARGET_TASK);
+  reset_task_stats(busy_task);
+  udelay(SIM_INTERVAL_US);
+  cgroup_task = poll_task(CGROUP_TASK);
+
+  send_sigcode(cgroup_task, SIGCODE_CGROUP_CREATE, 0);
+  send_sigcode2(cgroup_task, SIGCODE_SETCPU_CGROUP, 1 << 16 | 0x0, 2);
+}
+
+static struct task_struct *find_last_task(void) {
+    struct task_struct *p;
+    struct task_struct *target;
+    for_each_process(p) {
+        if (strcmp(p->comm, TARGET_TASK) != 0)
+          continue;
+        target = p;
+    }
+    return target;
+}
+
+static void controller_body(void) {
+    for (int i = 0; i < 3; i++) {
+        send_sigcode2(busy_task, SIGCODE_FORK_PIN, 1, 2);
+        struct task_struct *pin_task = find_last_task();
+        send_sigcode(pin_task, SIGCODE_REWEIGHT, 19);
+    }
+    
+    send_sigcode(busy_task, SIGCODE_CLONE3_L1_0, 1);
+    struct task_struct *l1_0_task = find_last_task();
+
+    for(int i = 0; i < 20; i++) {
+        call_tick_once(true);
+    }
+
+    send_sigcode2(cgroup_task, SIGCODE_REWEIGHT_CGROUP, 1 << 16 | 0x0, 10000);
+
+    for(int i = 0; i < 10; i++) {
+        call_tick_once(true);
+    }
+    print_tasks();
+
+}
+
+struct controller_ops controller_5068d84 = {
+    .name = "5068d84",
+    .init = controller_init,
+    .body = controller_body,
+};

--- a/kmod/bug-bbce3de.c
+++ b/kmod/bug-bbce3de.c
@@ -65,12 +65,12 @@ static void controller_init(void) {
   send_sigcode(cgroup_task, SIGCODE_CGROUP_CREATE, 2 << 16 | 0x0);
 
   // set up the configuration for the cgroup tree
-  send_sigcode(cgroup_task, SIGCODE_REWEIGHT_CGROUP_20, 3 << 16 | 0x0);
-  send_sigcode(cgroup_task, SIGCODE_SETCPU_CGROUP_1, 1 << 16 | 0x0);
-  send_sigcode(cgroup_task, SIGCODE_SETCPU_CGROUP_1, 2 << 16 | 0x0);
-  send_sigcode(cgroup_task, SIGCODE_SETCPU_CGROUP_1, 2 << 16 | 0x1);
-  send_sigcode(cgroup_task, SIGCODE_SETCPU_CGROUP_1, 3 << 16 | 0x0);
-  send_sigcode(cgroup_task, SIGCODE_SETCPU_CGROUP_1, 3 << 16 | 0x1);
+  send_sigcode2(cgroup_task, SIGCODE_REWEIGHT_CGROUP, 3 << 16 | 0x0, 20);
+  send_sigcode2(cgroup_task, SIGCODE_SETCPU_CGROUP, 1 << 16 | 0x0, 1);
+  send_sigcode2(cgroup_task, SIGCODE_SETCPU_CGROUP, 2 << 16 | 0x0, 1);
+  send_sigcode2(cgroup_task, SIGCODE_SETCPU_CGROUP, 2 << 16 | 0x1, 1);
+  send_sigcode2(cgroup_task, SIGCODE_SETCPU_CGROUP, 3 << 16 | 0x0, 1);
+  send_sigcode2(cgroup_task, SIGCODE_SETCPU_CGROUP, 3 << 16 | 0x1, 1);
 
   // create 1 task in l3_0
   send_sigcode(busy_task, SIGCODE_CLONE3_L3_0, 1);
@@ -142,7 +142,7 @@ static void controller_body(void) {
 
   ksym.dequeue_entities(ineligible_tg_se->cfs_rq, ineligible_tg_se, DEQUEUE_SLEEP);
   struct task_struct *p = get_curr_task(cpu_of_ineligible_task);
-  send_sigcode(cgroup_task, SIGCODE_REWEIGHT_CGROUP_100, 3 << 16 | 0x0);
+  send_sigcode2(cgroup_task, SIGCODE_REWEIGHT_CGROUP, 3 << 16 | 0x0, 100);
 
   send_sigcode(p, SIGCODE_CLONE3_L3_0, 1);
 

--- a/kmod/controller.h
+++ b/kmod/controller.h
@@ -11,6 +11,7 @@ extern struct controller_ops controller_bbce3de;
 extern struct controller_ops controller_cd9626e;
 extern struct controller_ops controller_2feab24;
 extern struct controller_ops controller_17e3e88;
+extern struct controller_ops controller_5068d84;
 extern struct controller_ops controller_noop;
 
 static struct controller_ops *controller_ops_list[] = {
@@ -19,6 +20,7 @@ static struct controller_ops *controller_ops_list[] = {
     &controller_cd9626e,
     &controller_2feab24,
     &controller_17e3e88,
+    &controller_5068d84,
     &controller_noop,
 };
 

--- a/kmod/ksym.h
+++ b/kmod/ksym.h
@@ -1,6 +1,10 @@
 #include <linux/mmu_context.h>
 #include <linux/types.h>
+#include <linux/version.h>
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6, 7, 0)
+#include <linux/sched/cputime.h>
+#endif
 #include <kernel/sched/sched.h> // private header
 
 // Define function symbols
@@ -22,7 +26,8 @@
   X(void, sched_yield, (void))                                                 \
   X(void, freeze_task, (struct task_struct * p))                               \
   X(void, tick_offline_cpu, (unsigned int cpu))                                \
-  X(void, dequeue_entities, (struct cfs_rq * cfs_rq, struct sched_entity * se, int flags))
+  X(void, dequeue_entities, (struct cfs_rq * cfs_rq, struct sched_entity * se, int flags)) \
+  X(u64, avg_vruntime, (struct cfs_rq * cfs_rq))
 
 // Define variable symbols
 // Format: X(type, var_name)

--- a/kmod/utils.c
+++ b/kmod/utils.c
@@ -88,10 +88,11 @@ void print_tasks(void) {
     h_nr_queued_val = rq->cfs.h_nr_queued;
 #endif
 
-    TRACE_INFO("- CPU %d running=%d, switches=%3lld, avg_load=%lld, avg_util=%lu", cpu,
+    TRACE_INFO("- CPU %d running=%d, switches=%3lld, avg_load=%lld, avg_util=%lu, min_vruntime=%lld, avg_vruntime=%lld", cpu,
                rq->nr_running - (h_nr_queued_val - h_nr_runnable_val),
                rq->nr_switches, rq->cfs.avg_load, 
-               rq->avg_rt.util_avg + rq->cfs.avg.util_avg + rq->avg_dl.util_avg);
+               rq->avg_rt.util_avg + rq->cfs.avg.util_avg + rq->avg_dl.util_avg,
+               rq->cfs.min_vruntime - INIT_TIME_NS, ksym.avg_vruntime(&rq->cfs) - INIT_TIME_NS);
   }
 
   int min_pid = INT_MAX;

--- a/linux/6.7-5068d84_fix.patch
+++ b/linux/6.7-5068d84_fix.patch
@@ -1,0 +1,44 @@
+From fc3757c9460fc2a7c3698d1ea1c3e10145225402 Mon Sep 17 00:00:00 2001
+From: Tingjia-0v0 <tjcao980311@gmail.com>
+Date: Fri, 7 Nov 2025 23:38:55 -0600
+Subject: [PATCH] 6.7-5068d84_fix
+
+---
+ kernel/sched/fair.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index 3c431d44d4cc..b45d4f8ea98c 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -3811,17 +3811,17 @@ static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
+ 	enqueue_load_avg(cfs_rq, se);
+ 	if (se->on_rq) {
+ 		update_load_add(&cfs_rq->load, se->load.weight);
+-		if (!curr) {
+-			/*
+-			 * The entity's vruntime has been adjusted, so let's check
+-			 * whether the rq-wide min_vruntime needs updated too. Since
+-			 * the calculations above require stable min_vruntime rather
+-			 * than up-to-date one, we do the update at the end of the
+-			 * reweight process.
+-			 */
++		if (!curr)
+ 			__enqueue_entity(cfs_rq, se);
+-			update_min_vruntime(cfs_rq);
+-		}
++			
++		/*
++		 * The entity's vruntime has been adjusted, so let's check
++		 * whether the rq-wide min_vruntime needs updated too. Since
++		 * the calculations above require stable min_vruntime rather
++		 * than up-to-date one, we do the update at the end of the
++		 * reweight process.
++		 */
++		update_min_vruntime(cfs_rq);
+ 	}
+ }
+ 
+-- 
+2.43.0
+

--- a/linux/6.7-vruntime_min_init.patch
+++ b/linux/6.7-vruntime_min_init.patch
@@ -1,0 +1,25 @@
+From b946dd79fed92a27cda43cc31f2478b4a826db80 Mon Sep 17 00:00:00 2001
+From: Tingjia-0v0 <tjcao980311@gmail.com>
+Date: Fri, 7 Nov 2025 23:35:10 -0600
+Subject: [PATCH] 6.7-vruntime_min_init
+
+---
+ kernel/sched/fair.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index d7a3c63a2171..3c431d44d4cc 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -12753,7 +12753,7 @@ static void set_next_task_fair(struct rq *rq, struct task_struct *p, bool first)
+ void init_cfs_rq(struct cfs_rq *cfs_rq)
+ {
+ 	cfs_rq->tasks_timeline = RB_ROOT_CACHED;
+-	u64_u32_store(cfs_rq->min_vruntime, (u64)(-(1LL << 20)));
++	cfs_rq->min_vruntime = 10ULL * NSEC_PER_SEC;
+ #ifdef CONFIG_SMP
+ 	raw_spin_lock_init(&cfs_rq->removed.lock);
+ #endif
+-- 
+2.43.0
+

--- a/plot/plot_min_vruntime.py
+++ b/plot/plot_min_vruntime.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Plot min_vruntime and avg_vruntime for CPU 2 over time from log files
+"""
+
+import re
+import matplotlib.pyplot as plt
+import sys
+import os
+import argparse
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts import PROJ_DIR, LOGS_DIR
+
+init_timestamp = 10.0
+
+def parse_log_file(log_file):
+    """
+    Parse the log file and extract timestamp, min_vruntime, and avg_vruntime for CPU 2
+
+    Expected format:
+    [timestamp] ... print_tasks: - CPU 2 ... min_vruntime=VALUE ... avg_vruntime=VALUE
+    avg_vruntime may be absent in old kernels or log files.
+    """
+    timestamps = []
+    min_vruntime_values = []
+    avg_vruntime_values = []
+
+    # Pattern to match lines with CPU 2, min_vruntime, and optionally avg_vruntime
+    pattern = r'\[\s*(\d+\.\d+)\].*CPU 2.*min_vruntime=([0-9]+)(?:.*avg_vruntime=([0-9]+))?'
+
+    with open(log_file, 'r') as f:
+        for line in f:
+            match = re.search(pattern, line)
+            if match and float(match.group(1)) >= init_timestamp:
+                timestamp = (float(match.group(1)) - init_timestamp) * 1000
+                min_vruntime = int(match.group(2))
+                if match.group(3) is not None:
+                    avg_vruntime = int(match.group(3))
+                else:
+                    avg_vruntime = None
+                timestamps.append(timestamp)
+                min_vruntime_values.append(min_vruntime)
+                avg_vruntime_values.append(avg_vruntime)
+    print(f"min_vruntime samples: {len(timestamps)}")
+    return timestamps, min_vruntime_values, avg_vruntime_values
+
+def plot_min_avg_vruntime(
+    timestamps_buggy, min_vruntime_buggy, avg_vruntime_buggy,
+    timestamps_fixed, min_vruntime_fixed, avg_vruntime_fixed,
+    bugId, output_file
+):
+    """
+    Plot min_vruntime and avg_vruntime for buggy and fixed in two subplots.
+    Top: min_vruntime as scatter.
+    Bottom: avg_vruntime as scatter using same shape, size.
+    """
+    # Make both subplots the same size as in plot_util_avg: two rows, one column, figsize=(6,3)
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 4), sharex=True)
+
+    # Top subplot: min_vruntime using scatter
+    ax1.scatter(
+        timestamps_buggy, min_vruntime_buggy,
+        s=36,
+        marker='o',
+        facecolor='#A72703',
+        edgecolor='black',
+        linewidth=0.5,
+        label='Buggy',
+        alpha=0.95,
+        zorder=2
+    )
+    ax1.scatter(
+        timestamps_fixed, min_vruntime_fixed,
+        s=60,
+        marker='s',
+        facecolor='none',
+        edgecolor='#BBC863',
+        linewidth=1.8,
+        label='Fixed',
+        alpha=0.95,
+        zorder=3
+    )
+    ax1.set_ylabel('min_vruntime')
+    ax1.set_title(f'{bugId} - min_vruntime')
+    ax1.grid(True, alpha=0.3)
+    if len(timestamps_buggy) > 0 and len(timestamps_fixed) > 0:
+        ax1.set_xlim(0, max(max(timestamps_buggy), max(timestamps_fixed)))
+    ax1.legend()
+
+    # Bottom subplot: avg_vruntime as scatter plot if we have those values.
+    # Only plot when at least one value is not None and enough points
+    def _valid_points(ts, vs):
+        return [(t, v) for t, v in zip(ts, vs) if v is not None]
+
+    buggy_valid = _valid_points(timestamps_buggy, avg_vruntime_buggy)
+    fixed_valid = _valid_points(timestamps_fixed, avg_vruntime_fixed)
+
+    shown_any = False
+
+    if buggy_valid:
+        t_buggy, v_buggy = zip(*buggy_valid)
+        ax2.scatter(
+            t_buggy, v_buggy,
+            s=36,
+            marker='o',
+            facecolor='#A72703',
+            edgecolor='black',
+            linewidth=0.5,
+            label='Buggy',
+            alpha=0.95,
+            zorder=2
+        )
+        shown_any = True
+    if fixed_valid:
+        t_fixed, v_fixed = zip(*fixed_valid)
+        ax2.scatter(
+            t_fixed, v_fixed,
+            s=60,
+            marker='s',
+            facecolor='none',
+            edgecolor='#BBC863',
+            linewidth=1.8,
+            label='Fixed',
+            alpha=0.95,
+            zorder=3
+        )
+        shown_any = True
+    ax2.set_xlabel('Time (ms)')
+    ax2.set_ylabel('avg_vruntime')
+    ax2.grid(True, alpha=0.3)
+    ax2.set_title(f'{bugId} - avg_vruntime')
+    # ax2.sharex with ax1 by default via sharex=True
+    # Legend only if we drew at least one valid plot
+    if shown_any:
+        ax2.legend()
+    else:
+        # If no data, indicate it
+        ax2.text(
+            0.5, 0.5, "No avg_vruntime data found",
+            transform=ax2.transAxes, ha='center', va='center', fontsize=10, color='grey'
+        )
+
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches='tight')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--controller", type=str, default="5068d84")
+    args = parser.parse_args()
+
+    bugId = args.controller
+
+    # Paths to the log files
+    log_dir = LOGS_DIR
+    buggy_log = log_dir / f'{bugId}_buggy.log'
+    fixed_log = log_dir / f'{bugId}_fixed.log'
+
+    output_file = f"{PROJ_DIR}/plot/{bugId}.pdf"
+
+    print(f"Parsing log file: {buggy_log}")
+    timestamps_buggy, min_vruntime_buggy, avg_vruntime_buggy = parse_log_file(buggy_log)
+    timestamps_fixed, min_vruntime_fixed, avg_vruntime_fixed = parse_log_file(fixed_log)
+
+    plot_min_avg_vruntime(
+        timestamps_buggy, min_vruntime_buggy, avg_vruntime_buggy,
+        timestamps_fixed, min_vruntime_fixed, avg_vruntime_fixed,
+        bugId, output_file
+    )
+
+if __name__ == '__main__':
+    main()

--- a/reproduce.py
+++ b/reproduce.py
@@ -13,7 +13,8 @@ versions_map = {
     "cd9626e": "6.12-rc3",
     "bbce3de": "6.14",
     "2feab24": "6.9",
-    "17e3e88": "6.9"
+    "17e3e88": "6.9",
+    "5068d84": "6.7"
 }
 
 plot_formats = {
@@ -21,7 +22,8 @@ plot_formats = {
     "cd9626e": "cur_task",
     "bbce3de": "cur_task",
     "2feab24": "rebalance",
-    "17e3e88": "util_avg"
+    "17e3e88": "util_avg",
+    "5068d84": "min_vruntime"
 }
 
 def patch_linux(linux_dir: Path, patch_file: Path):


### PR DESCRIPTION
<img width="425" height="279" alt="image" src="https://github.com/user-attachments/assets/64b02b9b-4cc0-46c2-9b20-d23024f42239" />

This bug has no significant impact. In the buggy version, min_vruntime is not updated only for one tick; this delay does not affect correctness. At the same time, the avg_vruntime, which depends on min_vruntime and determines the initial vruntime of newly forked tasks, remains accurate.