### PR TITLE
Support disabling tick on older linux

### DIFF
--- a/kmod/controller.c
+++ b/kmod/controller.c
@@ -30,7 +30,12 @@ void call_tick_once(bool print_tasks_flag) {
 
 static void disable_timer_ticks(void) {
   for (int cpu = 1; cpu < num_online_cpus(); cpu++) {
-    ksym.tick_sched_timer_dying(cpu);
+    // Ref: tick_sched_timer_dying in
+    // https://elixir.bootlin.com/linux/v6.14/source/kernel/time/tick-sched.c#L1606
+    struct tick_sched *ts = ksym.tick_get_tick_sched(cpu);
+    hrtimer_cancel(&ts->sched_timer);
+    memset(ts, 0, sizeof(struct tick_sched));
+    TRACE_INFO("Disabled timer ticks on CPU %d", cpu);
   }
 }
 

--- a/kmod/ksym.c
+++ b/kmod/ksym.c
@@ -29,7 +29,7 @@ static void *get_addr(const char *name, void *default_addr) {
   }
 }
 
-static void fn_stub(void) { TRACE_ERR("Uninitialized kernel symbol"); }
+static void fn_stub(void) { panic("Uninitialized kernel function called"); }
 
 void ksym_init(void) {
   ksym.kallsyms_lookup_name = get_kallsyms_lookup_name();

--- a/kmod/ksym.h
+++ b/kmod/ksym.h
@@ -41,7 +41,7 @@
   X(unsigned long, arch_freq_scale)                                            \
   X(const struct sched_class, rt_sched_class)
 
-    struct ksym_t {
+struct ksym_t {
   void *(*kallsyms_lookup_name)(const char *name);
 
 #define X(ret_type, name, args) ret_type(*name) args;

--- a/kmod/ksym.h
+++ b/kmod/ksym.h
@@ -1,11 +1,10 @@
 #include <linux/mmu_context.h>
-#include <linux/types.h>
-#include <linux/version.h>
-
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(6, 7, 0)
 #include <linux/sched/cputime.h>
-#endif
-#include <kernel/sched/sched.h> // private header
+#include <linux/types.h>
+
+// private headers
+#include <kernel/sched/sched.h>
+#include <kernel/time/tick-sched.h>
 
 // Define function symbols
 // Format: X(ret_type, func_name, args)
@@ -26,8 +25,10 @@
   X(void, sched_yield, (void))                                                 \
   X(void, freeze_task, (struct task_struct * p))                               \
   X(void, tick_offline_cpu, (unsigned int cpu))                                \
-  X(void, dequeue_entities, (struct cfs_rq * cfs_rq, struct sched_entity * se, int flags)) \
-  X(u64, avg_vruntime, (struct cfs_rq * cfs_rq))
+  X(void, dequeue_entities,                                                    \
+    (struct cfs_rq * cfs_rq, struct sched_entity * se, int flags))             \
+  X(u64, avg_vruntime, (struct cfs_rq * cfs_rq))                               \
+  X(struct tick_sched *, tick_get_tick_sched, (int cpu))
 
 // Define variable symbols
 // Format: X(type, var_name)
@@ -36,11 +37,11 @@
   X(void, cd)                                                                  \
   X(u64, __sched_clock_offset)                                                 \
   X(unsigned int, sysctl_sched_migration_cost)                                 \
-  X(bool, pm_freezing)                                                          \
-  X(unsigned long, arch_freq_scale)                                             \
+  X(bool, pm_freezing)                                                         \
+  X(unsigned long, arch_freq_scale)                                            \
   X(const struct sched_class, rt_sched_class)
 
-struct ksym_t {
+    struct ksym_t {
   void *(*kallsyms_lookup_name)(const char *name);
 
 #define X(ret_type, name, args) ret_type(*name) args;

--- a/kmod/trace.c
+++ b/kmod/trace.c
@@ -15,6 +15,7 @@ static int trace_func_count = 0;
 module_param_array(trace_funcs, charp, &trace_func_count, 0644);
 MODULE_PARM_DESC(trace_funcs, "Function names to trace");
 
+#if 0
 void print_rq_json(struct rq *rq) {
   int h_nr_runnable_val = 0, h_nr_queued_val = 0, h_nr_idle_val = 0,
       nr_queued_val = 0;
@@ -152,6 +153,7 @@ void print_sched_state_json(void) {
     print_task_json(p);
   }
 }
+#endif
 
 static void sched_tick_cb(unsigned long ip, unsigned long parent_ip,
                           struct ftrace_ops *op, struct ftrace_regs *fregs) {

--- a/kmod/trace.c
+++ b/kmod/trace.c
@@ -9,7 +9,6 @@
 #include "ksym.h"
 #include "logging.h"
 
-#ifdef KSTEP_TRACE_SCHED
 // Module parameters
 static char *trace_funcs[32] = {};
 static int trace_func_count = 0;
@@ -25,6 +24,14 @@ void print_rq_json(struct rq *rq) {
   h_nr_idle_val = rq->cfs.h_nr_idle;
   nr_queued_val = rq->cfs.nr_queued;
 #endif
+
+// https://github.com/torvalds/linux/commit/11137d384996bb05cf33c8163db271e1bac3f4bf
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+  unsigned int util_est = rq->cfs.avg.util_est;
+#else
+  unsigned int util_est = rq->cfs.avg.util_est.enqueued;
+#endif
+
   pr_info("{"
           "\"rq[%d]\": "
           "{"
@@ -66,7 +73,7 @@ void print_rq_json(struct rq *rq) {
           rq->cpu, rq->cfs.min_vruntime, rq->cfs.avg_vruntime, nr_queued_val,
           h_nr_runnable_val, h_nr_queued_val, h_nr_idle_val,
           rq->cfs.load.weight, rq->cfs.avg.load_avg, rq->cfs.avg.runnable_avg,
-          rq->cfs.avg.util_avg, rq->cfs.avg.util_est, rq->cfs.removed.load_avg,
+          rq->cfs.avg.util_avg, util_est, rq->cfs.removed.load_avg,
           rq->cfs.removed.util_avg, rq->cfs.removed.runnable_avg,
           rq->cfs.tg_load_avg_contrib, atomic_long_read(&rq->cfs.tg->load_avg));
   pr_info("{\"rt_rq[%d]\": {\"rt_nr_running\": %u}}", rq->cpu,
@@ -204,6 +211,7 @@ struct trace_func_info {
 
 static struct trace_func_info trace_func_infos[] = {
     {.callback = &sched_tick_cb, .name = "sched_tick"},
+    {.callback = &sched_tick_cb, .name = "scheduler_tick"},
     {.callback = &update_rq_clock_cb, .name = "update_rq_clock"},
     {.callback = &sched_balance_domains_cb, .name = "sched_balance_domains"},
     {.callback = &sched_balance_rq_cb, .name = "sched_balance_rq"},
@@ -260,11 +268,3 @@ void sched_trace_exit(void) {
   }
   TRACE_INFO("Scheduler trace uninitialized");
 }
-#else
-int sched_trace_init(void) {
-  return 0;
-}
-
-void sched_trace_exit(void) {
-}
-#endif


### PR DESCRIPTION
```sh
./fetch_linux.py --version 6.7
./make_linux.py 
./run_qemu.py --params trace_funcs=scheduler_tick
cat ./data/logs/latest.log | grep "sched_tick called on"
```

```
[   10.001000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.001000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.002000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.002000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.003000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.003000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.004000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.004000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.005000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.005000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.006000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.006000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.007000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.007000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.008000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.008000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.009000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.009000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
[   10.010000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 1
[   10.010000] [             trace.c:162]            sched_tick_cb: sched_tick called on CPU 2
```

<img width="1222" height="658" alt="image" src="https://github.com/user-attachments/assets/57f951ff-3968-4fb4-8755-4e9a81c66f43" />
