### PR TITLE
the buggy behavior of a new bug about rebalance

### DIFF
--- a/kmod/bug-evenIdleCpu.c
+++ b/kmod/bug-evenIdleCpu.c
@@ -1,0 +1,53 @@
+#include <linux/delay.h>
+#include <linux/kthread.h>
+
+#include "controller.h"
+#include "internal.h"
+#include "ksym.h"
+#include "logging.h"
+#include "sigcode.h"
+
+#define TARGET_TASK "test-proc"
+#define CGROUP_TASK "cgroup-proc"
+
+static struct task_struct *busy_task;
+static struct task_struct *cgroup_task;
+
+static void controller_init(void) {
+  busy_task = poll_task(TARGET_TASK);
+  reset_task_stats(busy_task);
+  udelay(SIM_INTERVAL_US);
+  send_sigcode(busy_task, SIGCODE_PIN, 1);
+  cgroup_task = poll_task(CGROUP_TASK);
+}
+
+static void controller_body(void) {
+  // making the nr_running on cpu 4-7 to [1, 0, 3, 1]
+  send_sigcode(busy_task, SIGCODE_PIN, 4);
+  send_sigcode3(busy_task, SIGCODE_FORK_PIN_RANGE, 3, 6, 6);
+  send_sigcode3(busy_task, SIGCODE_FORK_PIN_RANGE, 1, 7, 7);
+  
+  for (int i = 0; i < 200; i++) {
+    call_tick_once(true);
+  }
+
+  struct task_struct *pin_task;
+  for_each_process(pin_task) {
+    if (strcmp(pin_task->comm, TARGET_TASK) != 0 || pin_task == busy_task)
+      continue;
+    if (task_cpu(pin_task) == 6)
+      send_sigcode2(pin_task, SIGCODE_PIN, 4, 6);
+  }
+
+
+  for(int i = 0; i < 1000; i++) {
+    call_tick_once(true);
+  }
+
+}
+
+struct controller_ops controller_evenIdleCpu = {
+    .name = "evenIdleCpu",
+    .init = controller_init,
+    .body = controller_body,
+};

--- a/kmod/controller.c
+++ b/kmod/controller.c
@@ -122,6 +122,12 @@ static void reset_rq(void) {
     // reset sched domain
     for (struct sched_domain *sd = rcu_dereference_check_sched_domain(rq->sd);
          sd; sd = sd->parent) {
+      // TRACE_INFO("sd: %d, %d, %d, %d", sd->span_weight, cpumask_first(sched_domain_span(sd)), cpumask_last(sched_domain_span(sd)), cpu);
+      // TRACE_INFO("sd->prefer_sibling: %d", sd->flags & SD_PREFER_SIBLING);
+      // TRACE_INFO("sd->share_pkg_resources: %d", sd->flags & SD_SHARE_PKG_RESOURCES);
+      // TRACE_INFO("sd->groups->prefer_sibling: %d", sd->groups->flags & SD_PREFER_SIBLING);
+      // TRACE_INFO("sd->groups->share_pkg_resources: %d\n", sd->groups->flags & SD_SHARE_PKG_RESOURCES);
+
       sd->last_balance = jiffies;
       sd->balance_interval = sd->min_interval;
       sd->nr_balance_failed = 0;

--- a/kmod/controller.h
+++ b/kmod/controller.h
@@ -12,6 +12,7 @@ extern struct controller_ops controller_cd9626e;
 extern struct controller_ops controller_2feab24;
 extern struct controller_ops controller_17e3e88;
 extern struct controller_ops controller_5068d84;
+extern struct controller_ops controller_evenIdleCpu;
 extern struct controller_ops controller_noop;
 
 static struct controller_ops *controller_ops_list[] = {
@@ -21,6 +22,7 @@ static struct controller_ops *controller_ops_list[] = {
     &controller_2feab24,
     &controller_17e3e88,
     &controller_5068d84,
+    &controller_evenIdleCpu,
     &controller_noop,
 };
 

--- a/kmod/sigcode.h
+++ b/kmod/sigcode.h
@@ -5,6 +5,7 @@
   X(SIGCODE_UNKNOWN)                                                           \
   X(SIGCODE_FORK)                                                              \
   X(SIGCODE_FORK_PIN)                                                          \
+  X(SIGCODE_FORK_PIN_RANGE)                                                    \
   X(SIGCODE_FORK_FF)                                                           \
   X(SIGCODE_CLONE3)                                                            \
   X(SIGCODE_CLONE3_L3_0)                                                       \
@@ -16,9 +17,10 @@
   X(SIGCODE_EXIT)                                                              \
   X(SIGCODE_PAUSE)                                                             \
   X(SIGCODE_CGROUP_CREATE)                                                     \
-  X(SIGCODE_SETCPU_CGROUP)                                                      \
-  X(SIGCODE_REWEIGHT_CGROUP)                                               \
-  X(SIGCODE_REWEIGHT)
+  X(SIGCODE_SETCPU_CGROUP)                                                     \
+  X(SIGCODE_REWEIGHT_CGROUP)                                                   \
+  X(SIGCODE_REWEIGHT)                                                          \
+  X(SIGCODE_PIN)
 
 enum sigcode {
 #define X(name) name,

--- a/kmod/trace.c
+++ b/kmod/trace.c
@@ -184,6 +184,9 @@ void print_sched_state_json(void) {
 #undef ftrace_override_function_with_return
 #define ftrace_override_function_with_return(fregs)                            \
   ksym.override_function_with_return(&arch_ftrace_regs(fregs)->regs)
+#else
+#undef ftrace_override_function_with_return
+#define ftrace_override_function_with_return(fregs) do { } while(0)
 #endif
 
 // do not call the original function, and directly return to the caller

--- a/linux/6.7-rc1-use_special_topo.patch
+++ b/linux/6.7-rc1-use_special_topo.patch
@@ -1,0 +1,50 @@
+From 7e6e5bb200379b549adbb41043488e969e368d40 Mon Sep 17 00:00:00 2001
+From: Tingjia-0v0 <tjcao980311@gmail.com>
+Date: Sun, 9 Nov 2025 03:41:33 -0600
+Subject: [PATCH] use_special_topo
+
+---
+ arch/x86/kernel/smpboot.c      | 7 +++----
+ include/linux/sched/topology.h | 8 +++++++-
+ 2 files changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/arch/x86/kernel/smpboot.c b/arch/x86/kernel/smpboot.c
+index 2cc2aa120b4b..cf9997cb10c4 100644
+--- a/arch/x86/kernel/smpboot.c
++++ b/arch/x86/kernel/smpboot.c
+@@ -615,10 +615,9 @@ static int x86_cluster_flags(void)
+ 
+ static int x86_die_flags(void)
+ {
+-	if (cpu_feature_enabled(X86_FEATURE_HYBRID_CPU))
+-	       return x86_sched_itmt_flags();
+-
+-	return 0;
++	// Qemu x86 does not support cluster CPU topology, simulate with die using cluster flags.
++	// TODO: using qemu arm to experiment this bug.
++	return cpu_cluster_flags() | x86_sched_itmt_flags();
+ }
+ 
+ /*
+diff --git a/include/linux/sched/topology.h b/include/linux/sched/topology.h
+index de545ba85218..684372c6114b 100644
+--- a/include/linux/sched/topology.h
++++ b/include/linux/sched/topology.h
+@@ -260,7 +260,13 @@ static inline void rebuild_sched_domains_energy(void)
+ static __always_inline
+ unsigned long arch_scale_cpu_capacity(int cpu)
+ {
+-	return SCHED_CAPACITY_SCALE;
++	// fake the asym cpu capacity.
++	// TODO: move this fake into kSTEP isntead of here.
++	if (cpu % 2 == 0) {
++		return SCHED_CAPACITY_SCALE;
++	} else {
++		return SCHED_CAPACITY_SCALE >> 1;
++	}
+ }
+ #endif
+ 
+-- 
+2.43.0
+

--- a/linux/6.7-rc1-vruntime_min_init.patch
+++ b/linux/6.7-rc1-vruntime_min_init.patch
@@ -1,0 +1,25 @@
+From 70104a399256eccf9bd0016c2a70600e9ca8f7e4 Mon Sep 17 00:00:00 2001
+From: Tingjia-0v0 <tjcao980311@gmail.com>
+Date: Sun, 9 Nov 2025 03:39:28 -0600
+Subject: [PATCH] vruntime_min_init
+
+---
+ kernel/sched/fair.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index 2048138ce54b..98a74a3fedc2 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -12644,7 +12644,7 @@ static void set_next_task_fair(struct rq *rq, struct task_struct *p, bool first)
+ void init_cfs_rq(struct cfs_rq *cfs_rq)
+ {
+ 	cfs_rq->tasks_timeline = RB_ROOT_CACHED;
+-	u64_u32_store(cfs_rq->min_vruntime, (u64)(-(1LL << 20)));
++	cfs_rq->min_vruntime = 10ULL * NSEC_PER_SEC;
+ #ifdef CONFIG_SMP
+ 	raw_spin_lock_init(&cfs_rq->removed.lock);
+ #endif
+-- 
+2.43.0
+

--- a/plot/plot_nr_running.py
+++ b/plot/plot_nr_running.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import re
+from collections import defaultdict
+import sys
+import os
+import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import colors
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from scripts import PROJ_DIR, LOGS_DIR
+
+# Adapted to allow color-matrix style plot, like plot_cur_task.py.
+# Only plot CPUs 4,5,6,7 -- CPUs 0,1,2,3 are not displayed or included
+all_cpus = [4, 5, 6, 7]  # restrict to 4-7
+
+# Use a discrete colormap (Blues) with N colors
+N_COLORS = 7  # Show only (at most) 7 distinct colors for the colorbar/colormap
+cmap = plt.cm.get_cmap('Blues', N_COLORS)
+
+def build_nr_running_matrix(filename, time_start=0.0):
+    """
+    Builds a 2D matrix: rows for cpus, columns for sorted timestamps, values = nr_running
+    Only collects values where timestamp >= time_start
+    Only considers CPUs in all_cpus (e.g., 4,5,6,7) for plotting/matrix.
+    """
+    pattern_nr_running = re.compile(r"\[\s*(\d+\.\d+)\].*?print_nr_running:\s+(\d+)\s+(\d+)")
+    pattern_print_tasks = re.compile(r"\[\s*(\d+\.\d+)\].*?print_tasks:.*?CPU\s+(\d+)\s+running=(\d+)")
+
+    cpu_ts2nr = defaultdict(dict)
+    all_timestamps = set()
+    min_running, max_running = float('inf'), float('-inf')
+    with open(filename, "r") as f:
+        for line in f:
+            m1 = pattern_nr_running.search(line)
+            m2 = pattern_print_tasks.search(line)
+            if m1:
+                ts = float(m1.group(1))
+                if ts < time_start:
+                    continue
+                cpu = int(m1.group(2))
+                nr_running = int(m1.group(3))
+                if cpu in all_cpus:
+                    cpu_ts2nr[cpu][ts] = nr_running
+                all_timestamps.add(ts)
+                min_running = min(min_running, nr_running)
+                max_running = max(max_running, nr_running)
+            elif m2:
+                ts = float(m2.group(1))
+                if ts < time_start:
+                    continue
+                cpu = int(m2.group(2))
+                nr_running = int(m2.group(3))
+                if cpu in all_cpus:
+                    cpu_ts2nr[cpu][ts] = nr_running
+                all_timestamps.add(ts)
+                min_running = min(min_running, nr_running)
+                max_running = max(max_running, nr_running)
+    all_timestamps = sorted(all_timestamps)
+    cpu_count = len(all_cpus)
+    time_count = len(all_timestamps)
+    nr_running_matrix = np.full((cpu_count, time_count), np.nan)
+    cpu_idx = {cpu: i for i, cpu in enumerate(all_cpus)}
+    for cpu in all_cpus:
+        for j, ts in enumerate(all_timestamps):
+            val = cpu_ts2nr[cpu].get(ts, np.nan)
+            nr_running_matrix[cpu_idx[cpu], j] = val
+            if not np.isnan(val):
+                min_running = min(min_running, val)
+                max_running = max(max_running, val)
+    return nr_running_matrix, cpu_count, time_count, all_timestamps, int(min_running), int(max_running)
+
+def plot_color_matrix(ax, matrix, cpu_count, time_count, vmin, vmax, timestamps, title_str):
+    # x ticks: in ms, offsets from the time_start
+    time_start = timestamps[0]
+    timestamps_ms = [(t-time_start)*1000 for t in timestamps]
+    # Use BoundaryNorm to make discrete color bins
+    bounds = np.linspace(vmin - 0.5, vmax + 0.5, N_COLORS + 1)
+    norm = colors.BoundaryNorm(boundaries=bounds, ncolors=cmap.N)
+    # Make the plot a little looser by adding some padding around the data
+    x_min = timestamps_ms[0]
+    x_max = timestamps_ms[-1]
+    y_min = all_cpus[0] - 0.7  # slightly more space above and below
+    y_max = all_cpus[-1] + 0.7
+
+    im = ax.imshow(
+        matrix, aspect="auto", interpolation="nearest", cmap=cmap, norm=norm,
+        extent=[x_min, x_max, y_min, y_max], origin="lower"
+    )
+    ax.set_yticks(range(len(all_cpus)))
+    ax.set_yticklabels(all_cpus)
+    ax.set_ylabel("CPU")
+    ax.set_xlabel("Time offset (ms)")
+    ax.set_title(title_str)
+    # x-ticks
+    n_xticks = 6 if len(timestamps_ms) > 6 else len(timestamps_ms)
+    x_tick_indices = np.linspace(0, len(timestamps_ms)-1, n_xticks, dtype=int)
+    x_ticks = [timestamps_ms[i] for i in x_tick_indices]
+    ax.set_xticks(x_ticks)
+    ax.set_xticklabels([f"{int(x)}" for x in x_ticks])
+
+    # Create colorbar with discrete color steps only
+    cbar = plt.colorbar(im, ax=ax, orientation='vertical', pad=0.03, fraction=0.07, boundaries=bounds, ticks=np.arange(vmin, vmax+1))
+    cbar.set_label("nr_running")
+    cbar.ax.set_yticklabels([str(int(t)) for t in np.arange(vmin, vmax+1)])
+
+    # Add some whitespace/padding around axes and content
+    ax.margins(0.03)
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--controller", type=str, default="evenIdleCpu")
+    parser.add_argument("--time-start", type=float, default=10.20, help="Only plot data from this time onward (in seconds)")
+    args = parser.parse_args()
+
+    bugId = args.controller
+    log_file_buggy = f"{LOGS_DIR}/{bugId}_buggy.log"
+    title_buggy = f"{bugId} (normal topology)"
+    log_file_fixed = f"{LOGS_DIR}/{bugId}_fixed.log"
+    title_fixed = f"{bugId} (special topology)"
+    output_file = f"{PROJ_DIR}/plot/{bugId}.pdf"
+
+    # Load data starting from 10.15 seconds (or what user set)
+    matrix_buggy, cpu_count, time_count, t_buggy, min_buggy, max_buggy = build_nr_running_matrix(log_file_buggy, time_start=args.time_start)
+    matrix_fixed, _, _, t_fixed, min_fixed, max_fixed = build_nr_running_matrix(log_file_fixed, time_start=args.time_start)
+    vmin = min(min_buggy, min_fixed)
+    vmax = max(max_buggy, max_fixed)
+
+    # Use sharex=False to avoid issues, and give a little more room on y axis
+    fig, axes = plt.subplots(2, 1, figsize=(10, 3.8), sharex=False, dpi=200)
+
+    plot_color_matrix(axes[0], matrix_buggy, cpu_count, time_count, vmin, vmax, t_buggy, title_buggy)
+    plot_color_matrix(axes[1], matrix_fixed, cpu_count, time_count, vmin, vmax, t_fixed, title_fixed)
+
+    plt.tight_layout()
+    # Avoid saving with the 'tight' option for less clipping, and allow more padding
+    plt.savefig(output_file, bbox_inches=None, pad_inches=0.2)

--- a/reproduce.py
+++ b/reproduce.py
@@ -14,7 +14,8 @@ versions_map = {
     "bbce3de": "6.14",
     "2feab24": "6.9",
     "17e3e88": "6.9",
-    "5068d84": "6.7"
+    "5068d84": "6.7",
+    "evenIdleCpu": "6.7-rc1"
 }
 
 plot_formats = {
@@ -23,7 +24,22 @@ plot_formats = {
     "bbce3de": "cur_task",
     "2feab24": "rebalance",
     "17e3e88": "util_avg",
-    "5068d84": "min_vruntime"
+    "5068d84": "min_vruntime",
+    "evenIdleCpu": "nr_running"
+}
+
+fix_patch_files = {
+    "evenIdleCpu": "use_special_topo.patch"
+}
+
+smp = {
+    "aa3ee4f": "cpus=3,cores=3",
+    "cd9626e": "cpus=3,cores=3",
+    "bbce3de": "cpus=3,cores=3",
+    "2feab24": "cpus=3,cores=3",
+    "17e3e88": "cpus=3,cores=3",
+    "5068d84": "cpus=3,cores=3",
+    "evenIdleCpu": "8,dies=4,cores=2,threads=1"
 }
 
 def patch_linux(linux_dir: Path, patch_file: Path):
@@ -61,10 +77,15 @@ def main(version: str, controller: str, clean: bool = False):
         linux_dir=linux_dir,
         params=[f"controller={controller}"],
         log_file=LOGS_DIR / f"{controller}_buggy.log",
+        smp=smp[controller],
     )
 
-    # Run the fixed version
-    patch_file = f"{PROJ_DIR}/linux/{version}-{controller}_fix.patch"
+    # Run the fixed version 
+    # for the new bug evenIdleCpu, we use the patch that generate special topo trigger the bug.
+    if controller not in fix_patch_files:
+        patch_file = f"{PROJ_DIR}/linux/{version}-{controller}_fix.patch"
+    else:
+        patch_file = f"{PROJ_DIR}/linux/{version}-{fix_patch_files[controller]}"
     patch_linux(linux_dir, patch_file)
 
     make_linux(linux_dir)
@@ -72,6 +93,7 @@ def main(version: str, controller: str, clean: bool = False):
         linux_dir=linux_dir,
         params=[f"controller={controller}"],
         log_file=LOGS_DIR / f"{controller}_fixed.log",
+        smp=smp[controller],
     )
 
     # plot the logs

--- a/run_qemu.py
+++ b/run_qemu.py
@@ -13,6 +13,7 @@ def run_qemu(
     debug: bool = False,
     log_file: Optional[Path] = None,
     params: Optional[List[str]] = None,
+    smp: str = "cpus=3,cores=3",
 ):
     system(f"make -C {PROJ_DIR} -j$(nproc)")
 
@@ -56,7 +57,7 @@ def run_qemu(
 
     cmd = [
         exe,
-        "-smp cpus=3,cores=3",
+        f"-smp {smp}",
         "-cpu max",
         "-m 25600M",
         f"-kernel {kernel_image_path}",
@@ -95,5 +96,7 @@ if __name__ == "__main__":
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--params", nargs="+", default=[])
     parser.add_argument("--log_file", type=Path, default=get_log_path(create=True))
+    parser.add_argument("--smp", type=str, default="cpus=3,cores=3")
+    # 8,dies=4,cores=2,threads=1
     args = parser.parse_args()
     run_qemu(**vars(args))

--- a/user/busy.c
+++ b/user/busy.c
@@ -47,7 +47,10 @@ static void signal_handler(int signum, siginfo_t *info, void *context) {
   int val = info->si_int;
   int val2 = info->si_pid;
   int val3 = info->si_uid;
-  if (code == SIGCODE_FORK || code == SIGCODE_FORK_PIN || code == SIGCODE_FORK_FF) {
+  if (code == SIGCODE_FORK ||
+      code == SIGCODE_FORK_PIN ||
+      code == SIGCODE_FORK_FF ||
+      code == SIGCODE_FORK_PIN_RANGE) {
     for (int i = 0; i < val; i++) {
       int pid = fork();
       if (pid == 0) {
@@ -55,6 +58,16 @@ static void signal_handler(int signum, siginfo_t *info, void *context) {
           cpu_set_t cpuset;
           CPU_ZERO(&cpuset);
           CPU_SET(val2, &cpuset);
+          int s = sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+          if (s != 0) {
+            perror("sched_setaffinity");
+          }
+        } else if (code == SIGCODE_FORK_PIN_RANGE) {
+          cpu_set_t cpuset;
+          CPU_ZERO(&cpuset);
+          for (int i = val2; i <= val3; i++) {
+            CPU_SET(i, &cpuset);
+          }
           int s = sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
           if (s != 0) {
             perror("sched_setaffinity");
@@ -87,6 +100,20 @@ static void signal_handler(int signum, siginfo_t *info, void *context) {
   } else if (code == SIGCODE_REWEIGHT) { 
     if (setpriority(PRIO_PROCESS, 0, val) == -1) {
       perror("setpriority");
+    }
+  } else if (code == SIGCODE_PIN) {
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(val, &cpuset);
+    if (val2 == 0) {
+      CPU_SET(val, &cpuset);
+    } else {
+      for (int i = val; i <= val2; i++)
+        CPU_SET(i, &cpuset);
+    }
+    int s = sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+    if (s != 0) {
+      perror("sched_setaffinity");
     }
   } else {
     printf("Unknown signal code: %d\n", code);

--- a/user/cgroup.c
+++ b/user/cgroup.c
@@ -198,7 +198,11 @@ static void signal_handler(int signum, siginfo_t *info, void *context) {
       return;
     }
     char buf[10];
-    size_t len = snprintf(buf, sizeof(buf), "%d", val2);
+    size_t len;
+    if (val3 == 0)
+      len = snprintf(buf, sizeof(buf), "%d", val2);
+    else
+      len = snprintf(buf, sizeof(buf), "%d-%d", val2, val3);
     if (len > 0 && len < sizeof(buf)) {
       write_file(cpuset_path, buf);
     } else {


### PR DESCRIPTION
<img width="720" height="274" alt="image" src="https://github.com/user-attachments/assets/0eb9ff21-a160-4475-a446-e130c459e095" />

In this special topology [[big, small], [big, small]], all four cores belong to the same socket, with each pair forming a cluster.
At the beginning of the test, the system state is as follows:

CPU	 	 	 |	 1	 |	 2	 |	 3	 |	 4	 |
	 	 	 ----------------------------------------
nr_running	 |	 1	 |	 0	 |	 3	 |	 1	 |

Under these conditions, the buggy rebalancing logic fails to pull a task from the busiest CPU (CPU 3) to the idlest CPU (CPU 2) after the whole second.