### PR TITLE
reproduce 6d7e478

### DIFF
--- a/kmod/bug-6d7e478.c
+++ b/kmod/bug-6d7e478.c
@@ -1,0 +1,54 @@
+#include <linux/delay.h>
+#include <linux/kthread.h>
+
+#include "controller.h"
+#include "internal.h"
+#include "ksym.h"
+#include "logging.h"
+#include "sigcode.h"
+
+#define TARGET_TASK "test-proc"
+#define CGROUP_TASK "cgroup-proc"
+
+static struct task_struct *busy_task;
+static struct task_struct *cgroup_task;
+
+static void controller_init(void) {
+  busy_task = poll_task(TARGET_TASK);
+  reset_task_stats(busy_task);
+  udelay(SIM_INTERVAL_US);
+  send_sigcode(busy_task, SIGCODE_PIN, 1);
+  cgroup_task = poll_task(CGROUP_TASK);
+}
+
+static void controller_body(void) {
+  // making the nr_running on cpu 4-7 to [1, 0, 3, 1]
+  send_sigcode(busy_task, SIGCODE_PIN, 4);
+  send_sigcode3(busy_task, SIGCODE_FORK_PIN_RANGE, 3, 6, 6);
+  send_sigcode3(busy_task, SIGCODE_FORK_PIN_RANGE, 1, 7, 7);
+  
+  for (int i = 0; i < 1000; i++) {
+    call_tick_once(true);
+  }
+
+  struct task_struct *pin_task;
+  for_each_process(pin_task) {
+    if (strcmp(pin_task->comm, TARGET_TASK) != 0 || pin_task == busy_task)
+      continue;
+    if (task_cpu(pin_task) == 6)
+      send_sigcode2(pin_task, SIGCODE_PIN, 4, 6);
+  }
+
+
+  for(int i = 0; i < 1000; i++) {
+    call_tick_once(true);
+  }
+
+}
+
+// smp 8,sockets=2,cores=2,threads=2
+struct controller_ops controller_6d7e478 = {
+    .name = "6d7e478",
+    .init = controller_init,
+    .body = controller_body,
+};

--- a/kmod/controller.h
+++ b/kmod/controller.h
@@ -13,6 +13,7 @@ extern struct controller_ops controller_2feab24;
 extern struct controller_ops controller_17e3e88;
 extern struct controller_ops controller_5068d84;
 extern struct controller_ops controller_evenIdleCpu;
+extern struct controller_ops controller_6d7e478;
 extern struct controller_ops controller_noop;
 
 static struct controller_ops *controller_ops_list[] = {
@@ -23,6 +24,7 @@ static struct controller_ops *controller_ops_list[] = {
     &controller_17e3e88,
     &controller_5068d84,
     &controller_evenIdleCpu,
+    &controller_6d7e478,
     &controller_noop,
 };
 

--- a/linux/6.7-rc1-6d7e478_fix.patch
+++ b/linux/6.7-rc1-6d7e478_fix.patch
@@ -1,0 +1,28 @@
+From b868962cf86f2d6e3303dedb1bd30cbacf5d7e52 Mon Sep 17 00:00:00 2001
+From: Tingjia-0v0 <tjcao980311@gmail.com>
+Date: Sun, 9 Nov 2025 16:04:19 -0600
+Subject: [PATCH] 6.7-rc1-6d7e478_fix
+
+---
+ kernel/sched/fair.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index bcd8df4aa6b6..04243cc9d518 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -11086,8 +11086,9 @@ static int should_we_balance(struct lb_env *env)
+ 		return cpu == env->dst_cpu;
+ 	}
+ 
+-	if (idle_smt == env->dst_cpu)
+-		return true;
++	/* Are we the first idle CPU with busy siblings? */
++	if (idle_smt != -1)
++		return idle_smt == env->dst_cpu;
+ 
+ 	/* Are we the first CPU of this group ? */
+ 	return group_balance_cpu(sg) == env->dst_cpu;
+-- 
+2.43.0
+

--- a/linux/6.7-rc1-vruntime_min_init-trace-lb.patch
+++ b/linux/6.7-rc1-vruntime_min_init-trace-lb.patch
@@ -1,0 +1,51 @@
+From 09de76fe35ba8b18a4f6b8ddafe6230a1ef869b8 Mon Sep 17 00:00:00 2001
+From: Tingjia-0v0 <tjcao980311@gmail.com>
+Date: Sun, 9 Nov 2025 16:02:57 -0600
+Subject: [PATCH] 6.7-rc1-vruntime_min_init-trace-lb
+
+---
+ kernel/sched/fair.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index 2048138ce54b..bcd8df4aa6b6 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -11057,6 +11057,9 @@ static int should_we_balance(struct lb_env *env)
+ 	cpumask_copy(swb_cpus, group_balance_mask(sg));
+ 	/* Try to find first idle CPU */
+ 	for_each_cpu_and(cpu, swb_cpus, env->cpus) {
++		// if (env->dst_cpu >= 4 && env->dst_cpu <= 7 && env->sd->span_weight == 4) {
++		// 	printk(KERN_DEBUG "SGMASK %d %d %d\n", env->dst_cpu, cpu, cpumask_weight(swb_cpus));
++		// }
+ 		if (!idle_cpu(cpu))
+ 			continue;
+ 
+@@ -11126,6 +11129,15 @@ static int load_balance(int this_cpu, struct rq *this_rq,
+ 		goto out_balanced;
+ 	}
+ 
++	if (this_cpu >= 4 && this_cpu <= 7) {
++		printk("LB %d %d %d %d %d\n", 
++			this_cpu, 
++			env.sd->span_weight, 
++			env.sd->groups->group_weight,
++			cpumask_first(sched_domain_span(env.sd)), 
++			cpumask_last(sched_domain_span(env.sd)));
++	}
++
+ 	group = find_busiest_group(&env);
+ 	if (!group) {
+ 		schedstat_inc(sd->lb_nobusyg[idle]);
+@@ -12644,7 +12656,7 @@ static void set_next_task_fair(struct rq *rq, struct task_struct *p, bool first)
+ void init_cfs_rq(struct cfs_rq *cfs_rq)
+ {
+ 	cfs_rq->tasks_timeline = RB_ROOT_CACHED;
+-	u64_u32_store(cfs_rq->min_vruntime, (u64)(-(1LL << 20)));
++	cfs_rq->min_vruntime = 10ULL * NSEC_PER_SEC;
+ #ifdef CONFIG_SMP
+ 	raw_spin_lock_init(&cfs_rq->removed.lock);
+ #endif
+-- 
+2.43.0
+

--- a/plot/plot_lb_event.py
+++ b/plot/plot_lb_event.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Plot load balancing events from log files
+"""
+
+import re
+import matplotlib.pyplot as plt
+import sys
+import os
+import argparse
+import math
+
+from matplotlib.ticker import MaxNLocator
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts import PROJ_DIR, LOGS_DIR
+
+init_timestamp = 10.0
+
+def parse_lb_events(log_file):
+    """
+    Parse the log file and extract LB events
+    
+    Expected format:
+    [timestamp] LB cpu weight ignored1 ignored2 ignored3
+    Example: [    0.322229] LB 7 2 1 6 7
+    Ignore those with weight 8.
+    """
+    lb_events = []
+    
+    # Pattern to match LB lines
+    pattern = r'\[\s*(\d+\.\d+)\]\s+LB\s+(\d+)\s+(\d+)'
+    
+    with open(log_file, 'r') as f:
+        for line in f:
+            match = re.search(pattern, line)
+            if match:
+                timestamp = float(match.group(1))
+                if timestamp >= init_timestamp:
+                    cpu = int(match.group(2))
+                    weight = int(match.group(3))
+                    # Ignore those with weight 8
+                    if weight == 8:
+                        continue
+                    # Convert to milliseconds relative to init_timestamp
+                    time_ms = (timestamp - init_timestamp) * 1000
+                    lb_events.append((time_ms, cpu, weight))
+    
+    return lb_events
+
+def plot_lb_events(events_buggy, events_fixed, bugId, output_file):
+    """
+    Plot LB events with different markers for different weights.
+    Use the same marker and visual style for both buggy and fixed subplots.
+    """
+    # Marker and color settings for all weights (shared for both subplots)
+    weight_styles = {
+        2: {'marker': 's', 'facecolor': 'none', 'edgecolor': '#28878a', 'label': 'Sched Domain (2 CPUs)', 'size': 65},  # hollow square
+        4: {'marker': 'o', 'facecolor': '#b23c1a', 'edgecolor': '#672613', 'label': 'Sched Domain (4 CPUs)', 'size': 90},  # deep red dot
+        16: {'marker': 'D', 'facecolor': '#FFA07A', 'edgecolor': '#a06343', 'label': 'Sched Domain (16 CPUs)', 'size': 65},
+        32: {'marker': 'v', 'facecolor': '#98D8C8', 'edgecolor': '#52856e', 'label': 'Sched Domain (32 CPUs)', 'size': 65},
+    }
+    fallback_style = {'marker': 'x', 'facecolor': 'gray', 'edgecolor': 'black', 'label': 'Other', 'size': 65}
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 3.8))
+
+    # ---- Plot for buggy version ----
+    ax1.set_title(f'{bugId} (buggy)')
+    ax1.set_ylabel('CPU')
+    ax1.set_xticklabels([])
+    # ax1.set_xlabel('Time (ms)')
+    ax1.grid(True, alpha=0.3)
+
+    weight_groups_buggy = {}
+    for time_ms, cpu, weight in events_buggy:
+        if weight == 8:
+            continue
+        if weight not in weight_groups_buggy:
+            weight_groups_buggy[weight] = {'times': [], 'cpus': []}
+        weight_groups_buggy[weight]['times'].append(time_ms)
+        weight_groups_buggy[weight]['cpus'].append(cpu)
+
+    for weight in sorted(weight_groups_buggy.keys()):
+        style = weight_styles.get(weight, fallback_style)
+        ax1.scatter(weight_groups_buggy[weight]['times'],
+                    weight_groups_buggy[weight]['cpus'],
+                    marker=style['marker'],
+                    facecolor=style['facecolor'],
+                    edgecolor=style['edgecolor'],
+                    label=style['label'],
+                    s=style['size'],
+                    lw=1.5 if style.get('facecolor', None) == 'none' else 1,
+                    alpha=0.85,
+        )
+
+    ax1.legend(loc='upper right', ncol = 1)
+
+    # ---- Plot for fixed version ----
+    ax2.set_title(f'{bugId} (fixed)')
+    ax2.set_ylabel('CPU')
+    ax2.set_xlabel('Time (ms)')
+    ax2.grid(True, alpha=0.3)
+
+    weight_groups_fixed = {}
+    for time_ms, cpu, weight in events_fixed:
+        if weight == 8:
+            continue
+        if weight not in weight_groups_fixed:
+            weight_groups_fixed[weight] = {'times': [], 'cpus': []}
+        weight_groups_fixed[weight]['times'].append(time_ms)
+        weight_groups_fixed[weight]['cpus'].append(cpu)
+
+    for weight in sorted(weight_groups_fixed.keys()):
+        style = weight_styles.get(weight, fallback_style)
+        ax2.scatter(weight_groups_fixed[weight]['times'],
+                    weight_groups_fixed[weight]['cpus'],
+                    marker=style['marker'],
+                    facecolor=style['facecolor'],
+                    edgecolor=style['edgecolor'],
+                    label=style['label'],
+                    s=style['size'],
+                    lw=1.5 if style.get('facecolor', None) == 'none' else 1,
+                    alpha=0.85,
+        )
+
+    # ax2.legend(loc='upper right', ncol = 1)
+
+    # Set same x/y limits
+    all_times = [e[0] for e in events_buggy if e[2] != 8] + [e[0] for e in events_fixed if e[2] != 8]
+    if all_times:
+        ax1.set_xlim(0, max(all_times))
+        ax2.set_xlim(0, max(all_times))
+
+    all_cpus = [e[1] for e in events_buggy if e[2] != 8] + [e[1] for e in events_fixed if e[2] != 8]
+    if all_cpus:
+        cpu_min, cpu_max = min(all_cpus), max(all_cpus)
+        ax1.set_ylim(cpu_min - 0.5, cpu_max + 0.5)
+        ax2.set_ylim(cpu_min - 0.5, cpu_max + 0.5)
+        # Set yticks to int only
+        ax1.yaxis.set_major_locator(MaxNLocator(integer=True))
+        ax2.yaxis.set_major_locator(MaxNLocator(integer=True))
+
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches='tight')
+    print(f"Plot saved to {output_file}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Plot load balancing events')
+    parser.add_argument("--controller", type=str, default="6d7e478",
+                       help="Bug ID / controller name")
+    args = parser.parse_args()
+
+    bugId = args.controller
+    
+    # Paths to the log files
+    log_dir = LOGS_DIR
+    buggy_log = log_dir / f'{bugId}_buggy.log'
+    fixed_log = log_dir / f'{bugId}_fixed.log'
+
+    output_file = f"{PROJ_DIR}/plot/{bugId}.pdf"
+    
+    print(f"Parsing buggy log: {buggy_log}")
+    events_buggy = parse_lb_events(buggy_log)
+    print(f"Found {len(events_buggy)} LB events in buggy version (before filtering weight 8)")
+    
+    print(f"Parsing fixed log: {fixed_log}")
+    events_fixed = parse_lb_events(fixed_log)
+    print(f"Found {len(events_fixed)} LB events in fixed version (before filtering weight 8)")
+    
+    if not events_buggy and not events_fixed:
+        print("No LB events found in log files")
+        return
+    
+    plot_lb_events(events_buggy, events_fixed, bugId, output_file)
+
+if __name__ == '__main__':
+    main()

--- a/reproduce.py
+++ b/reproduce.py
@@ -35,6 +35,12 @@ bugs = [
         smp="8,dies=4,cores=2,threads=1",
         fix_patch_file="use_special_topo.patch",
     ),
+    Bug(
+        name="6d7e478", 
+        version="6.7-rc1", 
+        plot_format="lb_event", 
+        smp="8,sockets=2,cores=2,threads=2"
+    ),
 ]
 
 def patch_linux(linux_dir: Path, patch_file: Path):
@@ -59,6 +65,8 @@ def main(bug: Bug):
     # Select appropriate patch file based on plot format type
     if bug.plot_format == "rebalance":
         suffix = "-vruntime_min_init-trace_rebalance.patch"
+    elif bug.plot_format == "lb_event":
+        suffix = "-vruntime_min_init-trace-lb.patch"
     else:
         suffix = "-vruntime_min_init.patch"
     patch_file = f"{PROJ_DIR}/linux/{bug.version}{suffix}"


### PR DESCRIPTION
<img width="425" height="265" alt="image" src="https://github.com/user-attachments/assets/22d23865-4b17-4a4f-b83e-1f56369e154f" />

The scheduler domain hierarchy is organized as two groups: [cpu4, cpu5] and [cpu6, cpu7].
Initially, all tasks are pinned, resulting in the following nr_running distribution: [1, 0] and [3, 1].

CPUs 4 and 5 belong to the same scheduler group. By design, when should_we_balance() is invoked to determine whether load balancing should occur, only one CPU within each scheduler group is expected to return true per tick. However, in the buggy version, when load balancing is triggered on the higher-level domain [4, 5, 6, 7], both CPU 4 and CPU 5 incorrectly decide to perform load balancing simultaneously. This leads to duplicate balancing operations and unnecessary overhead.