### PR TITLE
Fix workqueue_offline_cpu warning in Linux 5.15

### DIFF
--- a/kmod/isolation.c
+++ b/kmod/isolation.c
@@ -2,8 +2,8 @@
 
 void kstep_disable_workqueue(void) {
   for (int cpu = 1; cpu < num_online_cpus(); cpu++) {
-    smp_call_function_single(cpu, (void *)ksym.workqueue_offline_cpu,
-                             (void *)(uintptr_t)cpu, 1);
+    work_on_cpu(cpu, (void *)ksym.workqueue_offline_cpu,
+                (void *)(uintptr_t)cpu);
     TRACE_INFO("Disabled workqueue on CPU %d", cpu);
   }
 }


### PR DESCRIPTION
```
BUG: scheduling while atomic: swapper/1/0/0x00010000
Modules linked in: kstep(O+)
CPU: 1 PID: 0 Comm: swapper/1 Tainted: G           O      5.15.0-kstep #1
Call Trace:
 <IRQ>
 dump_stack_lvl+0x33/0x42
 __schedule_bug.cold+0x4b/0x58
 __schedule+0x41b/0x610
 ? __set_cpus_allowed_ptr_locked+0x155/0x190
 schedule+0x33/0x70
 workqueue_offline_cpu+0xed/0x1d0
 flush_smp_call_function_queue+0x112/0x190
 __sysvec_call_function_single+0x2b/0xa0
 sysvec_call_function_single+0x61/0x80
 </IRQ>
 asm_sysvec_call_function_single+0xf/0x20
```